### PR TITLE
Update serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ version = "0.7.10"
 [dependencies]
 log = "0.3.6"
 rand = "0.3.14"
-serde = "0.7.10"
-serde_json = "0.7.1"
+serde = "0.8.19"
+serde_json = "0.8.3"
 
 [dependencies.clippy]
 optional = true
@@ -43,9 +43,9 @@ version = "0.0"
 optional = true
 version = "0.9.5"
 
-[dependencies.serde_macros]
+[dependencies.serde_derive]
 optional = true
-version = "0.7.10"
+version = "0.8.19"
 
 [dependencies.url]
 features = ["serde"]
@@ -53,6 +53,6 @@ version = "1.1.1"
 
 [features]
 default = ["hyper", "with-syntex"]
-nightly = ["serde_macros"]
+nightly = ["serde_derive"]
 nightly-testing = ["clippy", "nightly"]
 with-syntex = ["serde_codegen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 #![deny(missing_docs)]
 #![deny(non_camel_case_types)]
 #![deny(warnings)]
+#![cfg_attr(feature = "nightly", feature(custom_derive, proc_macro))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "nightly", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "nightly", plugin(serde_macros))]
 
 //! A library providing Rust bindings for the XKCD web API.
 //!
@@ -34,6 +34,9 @@ extern crate hyper;
 extern crate log;
 extern crate rand;
 extern crate serde;
+#[cfg(feature = "nightly")]
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate url;
 
@@ -63,7 +66,7 @@ fn parse_xkcd_response<T>(response: &str) -> Result<T>
 /// Should be implemented for clients to send requests to the XKCD API.
 pub trait XkcdRequestSender {
     /// Performs an API call to the XKCD web API.
-    fn send<'a>(&self, method: &str) -> HttpRequestResult<String>;
+    fn send(&self, method: &str) -> HttpRequestResult<String>;
 }
 
 #[cfg(feature = "hyper")]
@@ -131,7 +134,7 @@ mod test_helpers {
     }
 
     impl XkcdRequestSender for MockXkcdRequestSender {
-        fn send<'a>(&self, _: &str) -> Result<String, HttpRequestError> {
+        fn send(&self, _: &str) -> Result<String, HttpRequestError> {
             Ok(self.response.clone())
         }
     }


### PR DESCRIPTION
Update to use the latest serde libraries (i.e. `serde_derive`), which uses the
new procedural macros.