### PR TITLE
Disable Travis CI OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,54 +16,23 @@ rust:
   - stable
 os:
   - linux
-  - osx
 cache:
   directories:
     - $HOME/.cargo
 before_script:
   # load travis-cargo
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        export PATH=$HOME/.local/bin/:$PATH
-      else
-        export PATH=$HOME/Library/Python/2.7/bin:$PATH
-      fi
-  - |
-      if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then
-        brew install openssl && \
-        export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include && \
-        export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib && \
-        echo "Installed OpenSSL for OS X."
-      fi
+  - pip install 'travis-cargo<0.2' --user
+  - export PATH=$HOME/.local/bin/:$PATH
 # the main build
 script:
-  - |
-      if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-        travis-cargo build -- --no-default-features
-      else
-        travis-cargo build
-      fi &&
-      if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-        travis-cargo test -- --no-default-features
-      else
-        travis-cargo test
-      fi &&
-      if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-        travis-cargo bench -- --no-default-features
-      else
-        travis-cargo bench
-      fi &&
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        travis-cargo --only stable doc
-      fi
+  - travis-cargo build
+  - travis-cargo test
+  - travis-cargo bench
+  - travis-cargo --only stable doc
 after_success:
   # upload the documentation from the build with stable (automatically only
   # actually runs from the master branch, not individual PRs), not on OS X.
-  - |
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        travis-cargo --only stable doc-upload
-      fi
+  - travis-cargo --only stable doc-upload
   # measure code coverage and upload to coveralls.io (the verify argument
   # mitigates kcov crashes due to malformed debuginfo, at the cost of some
   # speed. <https://github.com/huonw/travis-cargo/issues/12>)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <table>
     <tr>
-        <td><strong>Linux / OS X</strong></td>
+        <td><strong>Linux</strong></td>
         <td><a href="https://travis-ci.org/indiv0/xkcd-rs" title="Travis Build Status"><img src="https://travis-ci.org/indiv0/xkcd-rs.svg?branch=master" alt="travis-badge"></img></a></td>
     </tr>
     <tr>

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+enum_trailing_comma = true
+fn_args_layout = "Block"
+format_strings = false
+match_block_trailing_comma = true
+match_wildcard_trailing_comma = true
+normalize_comments = false
+struct_trailing_comma = "Always"
+struct_lit_trailing_comma = "Always"
+reorder_imports = true
+reorder_imported_names = true
+report_todo = "Always"
+report_fixme = "Always"
+where_trailing_comma = true
+write_mode = "Overwrite"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,12 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use serde_json;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 use std::result::Result as StdResult;
-
-use serde_json;
 use url::Url;
 
 /// A convenient alias type for results for `xkcd`.
@@ -82,8 +81,8 @@ impl PartialEq<Error> for Error {
 
         match (self, other) {
             (&HttpRequest(_), &HttpRequest(_)) |
-                (&Io(_), &Io(_)) |
-                (&Json(_), &Json(_)) => true,
+            (&Io(_), &Io(_)) |
+            (&Json(_), &Json(_)) => true,
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod hyper_support {
     use super::XkcdRequestSender;
 
     impl XkcdRequestSender for hyper::Client {
-        fn send<'a>(&self, method: &str) -> HttpRequestResult<String> {
+        fn send(&self, method: &str) -> HttpRequestResult<String> {
             let url_string = format!("https://xkcd.com/{}", method);
             let url = url_string.parse::<Url>().expect("Unable to parse URL");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,8 @@ pub mod comics;
 pub mod model;
 pub mod random;
 
-use std::fmt::Debug;
-
 use serde::Deserialize;
+use std::fmt::Debug;
 
 fn parse_xkcd_response<T>(response: &str) -> Result<T>
     where T: Debug + Deserialize,
@@ -70,15 +69,13 @@ pub trait XkcdRequestSender {
 
 #[cfg(feature = "hyper")]
 mod hyper_support {
-    use std::io::Read;
-
-    use hyper;
-    use hyper::status::StatusCode;
-    use url::Url;
 
     use error::{HttpRequestError, HttpRequestResult};
-
+    use hyper;
+    use hyper::status::StatusCode;
+    use std::io::Read;
     use super::XkcdRequestSender;
+    use url::Url;
 
     impl XkcdRequestSender for hyper::Client {
         fn send(&self, method: &str) -> HttpRequestResult<String> {
@@ -117,7 +114,7 @@ pub use hyper_support::*;
 
 #[cfg(test)]
 mod test_helpers {
-    use super::{XkcdRequestSender, HttpRequestError};
+    use super::{HttpRequestError, XkcdRequestSender};
 
     pub struct MockXkcdRequestSender {
         response: String,
@@ -125,7 +122,7 @@ mod test_helpers {
 
     impl MockXkcdRequestSender {
         pub fn respond_with<S: Into<String>>(response: S) -> Self {
-            MockXkcdRequestSender { response: response.into() }
+            MockXkcdRequestSender { response: response.into(), }
         }
     }
 
@@ -138,11 +135,9 @@ mod test_helpers {
 
 #[cfg(test)]
 mod tests {
-    use url::Url;
-
     use model::XkcdResponse;
-
     use super::parse_xkcd_response;
+    use url::Url;
 
     #[test]
     fn test_parse_xkcd_response() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,8 @@ mod hyper_support {
 
             trace!("Status code: {}", response.status);
             // Ensure we got a valid status code.
-            match response.status {
-                StatusCode::NotFound => return Err(HttpRequestError::not_found(url)),
-                _ => {}
+            if let StatusCode::NotFound = response.status {
+                return Err(HttpRequestError::not_found(url));
             }
 
             let mut result = String::new();

--- a/src/model.rs
+++ b/src/model.rs
@@ -48,10 +48,9 @@ pub struct XkcdResponse {
 #[cfg(test)]
 mod tests {
     use serde_json::from_str;
-    use url::Url;
-
     use super::XkcdResponse;
     use super::super::parse_xkcd_response;
+    use url::Url;
 
     #[test]
     fn test_parse_xkcd_response() {

--- a/src/random.rs
+++ b/src/random.rs
@@ -9,14 +9,11 @@
 
 //! Retrieves information on a random XKCD comic.
 
-use std::ops::Range;
-
+use comics;
 use error::Result;
 use model::XkcdResponse;
 use rand::{self, Rng};
-
-use comics;
-
+use std::ops::Range;
 use super::XkcdRequestSender;
 
 /// Retrieves information regarding a random comic from the XKCD website in the


### PR DESCRIPTION
Disable OS X CI builds on Travis CI.
Remove OS X build label from `README.md`.
Closes #8.

Also closes #10.